### PR TITLE
Rebuild dist/index.js after undici 5.28.5 bump

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -10174,6 +10174,14 @@ const { isUint8Array, isArrayBuffer } = __nccwpck_require__(9830)
 const { File: UndiciFile } = __nccwpck_require__(8511)
 const { parseMIMEType, serializeAMimeType } = __nccwpck_require__(685)
 
+let random
+try {
+  const crypto = __nccwpck_require__(6005)
+  random = (max) => crypto.randomInt(0, max)
+} catch {
+  random = (max) => Math.floor(Math.random(max))
+}
+
 let ReadableStream = globalThis.ReadableStream
 
 /** @type {globalThis['File']} */
@@ -10259,7 +10267,7 @@ function extractBody (object, keepalive = false) {
     // Set source to a copy of the bytes held by object.
     source = new Uint8Array(object.buffer.slice(object.byteOffset, object.byteOffset + object.byteLength))
   } else if (util.isFormDataLike(object)) {
-    const boundary = `----formdata-undici-0${`${Math.floor(Math.random() * 1e11)}`.padStart(11, '0')}`
+    const boundary = `----formdata-undici-0${`${random(1e11)}`.padStart(11, '0')}`
     const prefix = `--${boundary}\r\nContent-Disposition: form-data`
 
     /*! formdata-polyfill. MIT License. Jimmy Wärting <https://jimmy.warting.se/opensource> */
@@ -25021,6 +25029,14 @@ module.exports = require("net");
 
 "use strict";
 module.exports = require("node:child_process");
+
+/***/ }),
+
+/***/ 6005:
+/***/ ((module) => {
+
+"use strict";
+module.exports = require("node:crypto");
 
 /***/ }),
 


### PR DESCRIPTION
## Summary

The `lint` job has been failing on every CI run since #7 (undici 5.28.4 → 5.28.5) because the bundled `dist/index.js` was never regenerated to match the updated `package-lock.json`. The job ends with `make -B dist/index.js && git diff --exit-code`, which rebuilds the bundle and asserts it is byte-identical to what is checked in — that check has been red since #7 landed.

This PR regenerates `dist/index.js` with `ncc` against the current lockfile so the check passes again. Failing run for reference: https://github.com/viamrobotics/build-action/actions/runs/25922775206/job/76195895410

## Changes

- **dist/index.js**: Regenerated via `make -B dist/index.js` so the committed bundle matches the lockfile (picks up `undici@5.28.5`'s new `crypto.randomInt`-based form-data boundary, plus the bundled `node:crypto` chunk).

## Testing

- The same command the lint job runs reproduces the failure on `main` and succeeds on this branch:
  ```
  make -B dist/index.js
  git diff --exit-code   # exits 0 here
  ```
- CI on this PR should now pass the `lint` job end-to-end.

## Tickets

None

## Claude Code Prompts Used

- "Hi Claude, can you review https://github.com/viamrobotics/build-action/actions/runs/25922775206/job/76195895410 and explain why it failed? What can we do to fix it?"